### PR TITLE
Update ttlockio to 0.3.1 with updated API domain

### DIFF
--- a/ttlock2mqtt/rootfs/tmp/requirements.txt
+++ b/ttlock2mqtt/rootfs/tmp/requirements.txt
@@ -1,2 +1,2 @@
-ttlockio == 0.2.1
+git+https://github.com/ndbroadbent/ttlockio@revert_toml_changes
 paho-mqtt == 1.6.1


### PR DESCRIPTION
See: https://github.com/tonyldo/ttlockio/issues/11

EDIT: I just saw that `0.3.2` is the latest version. Have updated the commit

EDIT2: `0.3.2` is crashing on `pip install`, see: https://github.com/tonyldo/ttlockio/issues/16
Will use `0.3.1` since it has the url change

EDIT3: Sorry the crash is happening with `0.3.1` as well